### PR TITLE
Fix ProductSyncedBatch create failing on null isErrorLogExistsForBatch

### DIFF
--- a/models/db/postgres/ProductSyncedBatch.js
+++ b/models/db/postgres/ProductSyncedBatch.js
@@ -149,12 +149,16 @@ class ProductSyncedBatchModel {
       createProductSkippedTotal: data.numbers?.createProductSkippedTotal || null,
       createProductSkippedAlreadySynced: data.numbers?.createProductSkippedAlreadySynced || null,
       createProductSkippedFailed: data.numbers?.createProductSkippedFailed || null,
-      isErrorLogExistsForBatch: data.isErrorLogExistsForThisBatch || null,
       traceId: data.traceId,
     };
 
     if (data.tenant) {
       normalized.tenantId = typeof data.tenant === 'object' ? data.tenant._id || data.tenant.id : data.tenant;
+    }
+
+    // Boolean field, cannot be null — omit when unset so Prisma uses @default(false)
+    if (data.isErrorLogExistsForThisBatch !== undefined && data.isErrorLogExistsForThisBatch !== null) {
+      normalized.isErrorLogExistsForBatch = Boolean(data.isErrorLogExistsForThisBatch);
     }
 
     return normalized;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`ProductSyncedBatch.create()` failed with:

```
Argument `isErrorLogExistsForBatch` must not be null.
```

This happened when callers (e.g. Shopify product sync) created a batch without passing `isErrorLogExistsForThisBatch`.

## Root cause

`_normalizeFromMongoFormat` in `models/db/postgres/ProductSyncedBatch.js` always set:

```js
isErrorLogExistsForBatch: data.isErrorLogExistsForThisBatch || null
```

When the field was omitted, Prisma received an explicit `null` for a non-nullable `Boolean` column (even though the schema has `@default(false)`).

## Fix

Omit `isErrorLogExistsForBatch` when the caller does not provide a value, so Prisma applies the schema default (`false`). When provided, coerce with `Boolean(...)`.

This matches the existing pattern in `OrderSyncBatch.js`.

## Testing

- `npm test -- tests/business/shopify/ProductBusiness.test.js` — 17 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4650-df74-7a7a-b23b-029fe53a793e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4650-df74-7a7a-b23b-029fe53a793e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

