### PR TITLE
Update Nebim customer email/SMS OptIn from consent endpoint

### DIFF
--- a/business/nebim/CustomerBusiness.js
+++ b/business/nebim/CustomerBusiness.js
@@ -212,7 +212,7 @@ export default class NebimCustomerClass extends CoreClass {
             CurrAccCode: nebimCustomer.CurrAccCode,
             Communications: communicationType === "gsm" ? [{
                 CommunicationTypeCode: this.tenant.nebim.customer.phoneType,
-                CommAddress: customer.phone,
+                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === this.tenant.nebim.customer.phoneType)[0].CommunicationID,
                 OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
                     Call: true,
                     CompanyBrandCode: "",
@@ -229,7 +229,7 @@ export default class NebimCustomerClass extends CoreClass {
                 } : {}
             }] : [{
                 CommunicationTypeCode: "3",
-                CommAddress: customer.email,
+                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === "3")[0].CommunicationID,
                 OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
                     Call: false,
                     CompanyBrandCode: "",

--- a/business/nebim/CustomerBusiness.js
+++ b/business/nebim/CustomerBusiness.js
@@ -197,13 +197,15 @@ export default class NebimCustomerClass extends CoreClass {
 
         if (!nebimCustomer) return null;
 
-        const nowIso = new Date().toISOString();
-        const emailConsentRaw = customer?.consents?.email?.date ?? nowIso;
-        const gsmConsentRaw = customer?.consents?.gsm?.date ?? nowIso;
+        const emailConsentRaw = customer?.consents?.email?.date;
+        const gsmConsentRaw = customer?.consents?.gsm?.date;
+        const consentRaw = communicationType === "gsm" ? gsmConsentRaw : emailConsentRaw;
+        if (!consentRaw) return { skipped: true, reason: "missing_consent_date" };
+
         const emailOptIn = customer?.consents?.email?.is_opt_in ?? false;
         const gsmOptIn = customer?.consents?.gsm?.is_opt_in ?? false;
-        const [ emailConsentDate, emailConsentTimeZ ] = emailConsentRaw.split("T");
-        const [ gsmConsentDate, gsmConsentTimeZ ] = gsmConsentRaw.split("T");
+        const [ emailConsentDate, emailConsentTimeZ ] = (emailConsentRaw ?? "").split("T");
+        const [ gsmConsentDate, gsmConsentTimeZ ] = (gsmConsentRaw ?? "").split("T");
 
         const result = await this.api.post({
             ModelType: 3,

--- a/business/nebim/CustomerBusiness.js
+++ b/business/nebim/CustomerBusiness.js
@@ -212,7 +212,7 @@ export default class NebimCustomerClass extends CoreClass {
             CurrAccCode: nebimCustomer.CurrAccCode,
             Communications: communicationType === "gsm" ? [{
                 CommunicationTypeCode: this.tenant.nebim.customer.phoneType,
-                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === this.tenant.nebim.customer.phoneType)[0].CommunicationID,
+                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === this.tenant.nebim.customer.phoneType && x.CommAddress == customer.phone)[0].CommunicationID,
                 OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
                     Call: true,
                     CompanyBrandCode: "",
@@ -229,7 +229,7 @@ export default class NebimCustomerClass extends CoreClass {
                 } : {}
             }] : [{
                 CommunicationTypeCode: "3",
-                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === "3")[0].CommunicationID,
+                CommunicationID: nebimCustomer.Communications.filter(x => x.CommunicationTypeCode === "3" && x.CommAddress == customer.email)[0].CommunicationID,
                 OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
                     Call: false,
                     CompanyBrandCode: "",

--- a/business/nebim/CustomerBusiness.js
+++ b/business/nebim/CustomerBusiness.js
@@ -103,6 +103,14 @@ export default class NebimCustomerClass extends CoreClass {
             DistrictCode: addressCodes.DistrictCode,
             Address: address.address_text
         };
+        const nowIso = new Date().toISOString();
+        const emailConsentRaw = customer?.consents?.email?.date ?? nowIso;
+        const gsmConsentRaw = customer?.consents?.gsm?.date ?? nowIso;
+        const emailOptIn = customer?.consents?.email?.is_opt_in ?? false;
+        const gsmOptIn = customer?.consents?.gsm?.is_opt_in ?? false;
+        const [ emailConsentDate, emailConsentTimeZ ] = emailConsentRaw.split("T");
+        const [ gsmConsentDate, gsmConsentTimeZ ] = gsmConsentRaw.split("T");
+
         const base = {
             ModelType: 3,
             FirstName: customer.first_name,
@@ -125,7 +133,44 @@ export default class NebimCustomerClass extends CoreClass {
                 EmailPermission: true,
                 AddressPermission: true
             }] : [],
-            Communications: this.#buildCommunications(customer),
+            Communications: [
+                {
+                    CommunicationTypeCode: "3",
+                    CommAddress: customer.email,
+                    OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
+                        Call: false,
+                        CompanyBrandCode: "",
+                        ConfirmationFormStatusCode: this.tenant.nebim.customer.confirmationFormStatusCode, 
+                        ConfirmationFormTypeCode: this.tenant.nebim.customer.confirmationFormTypeCode, 
+                        ConsentDate: emailConsentDate,
+                        ConsentTime: emailConsentTimeZ.replace("Z", "").split(".")[0],
+                        ConsentSource: this.tenant.nebim.customer.consentSource,
+                        Email: true,
+                        FormNumber: "digital",
+                        OptIn: emailOptIn,
+                        RecipientType: 1,
+                        SMS: false
+                    } : {}
+                },
+                {
+                    CommunicationTypeCode: this.tenant.nebim.customer.phoneType,
+                    CommAddress: customer.phone,
+                    OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
+                        Call: true,
+                        CompanyBrandCode: "",
+                        ConfirmationFormStatusCode: this.tenant.nebim.customer.confirmationFormStatusCode, 
+                        ConfirmationFormTypeCode: this.tenant.nebim.customer.confirmationFormTypeCode, 
+                        ConsentDate: gsmConsentDate,
+                        ConsentTime: gsmConsentTimeZ.replace("Z", "").split(".")[0],
+                        ConsentSource: this.tenant.nebim.customer.consentSource,
+                        Email: false,
+                        FormNumber: "digital",
+                        OptIn: gsmOptIn,
+                        RecipientType: 1,
+                        SMS: true
+                    } : {}
+                }
+            ],
             Contacts: [is_receiver_not_customer ? {
                 ContactTypeCode: "C",
                 FirstName: address.first_name,
@@ -152,80 +197,57 @@ export default class NebimCustomerClass extends CoreClass {
 
         if (!nebimCustomer) return null;
 
-        const communications = this.#buildCommunications(customer);
-        const communicationsToSend = communicationType === "email"
-            ? [communications[0]]
-            : communicationType === "gsm"
-                ? [communications[1]]
-                : communications;
+        const nowIso = new Date().toISOString();
+        const emailConsentRaw = customer?.consents?.email?.date ?? nowIso;
+        const gsmConsentRaw = customer?.consents?.gsm?.date ?? nowIso;
+        const emailOptIn = customer?.consents?.email?.is_opt_in ?? false;
+        const gsmOptIn = customer?.consents?.gsm?.is_opt_in ?? false;
+        const [ emailConsentDate, emailConsentTimeZ ] = emailConsentRaw.split("T");
+        const [ gsmConsentDate, gsmConsentTimeZ ] = gsmConsentRaw.split("T");
 
         const result = await this.api.post({
             ModelType: 3,
             CurrAccCode: nebimCustomer.CurrAccCode,
-            Communications: communicationsToSend
+            Communications: communicationType === "gsm" ? [{
+                CommunicationTypeCode: this.tenant.nebim.customer.phoneType,
+                CommAddress: customer.phone,
+                OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
+                    Call: true,
+                    CompanyBrandCode: "",
+                    ConfirmationFormStatusCode: this.tenant.nebim.customer.confirmationFormStatusCode,
+                    ConfirmationFormTypeCode: this.tenant.nebim.customer.confirmationFormTypeCode,
+                    ConsentDate: gsmConsentDate,
+                    ConsentTime: gsmConsentTimeZ.replace("Z", "").split(".")[0],
+                    ConsentSource: this.tenant.nebim.customer.consentSource,
+                    Email: false,
+                    FormNumber: "digital",
+                    OptIn: gsmOptIn,
+                    RecipientType: 1,
+                    SMS: true
+                } : {}
+            }] : [{
+                CommunicationTypeCode: "3",
+                CommAddress: customer.email,
+                OptInOptOutStatusIntegrator: (this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode) ? {
+                    Call: false,
+                    CompanyBrandCode: "",
+                    ConfirmationFormStatusCode: this.tenant.nebim.customer.confirmationFormStatusCode,
+                    ConfirmationFormTypeCode: this.tenant.nebim.customer.confirmationFormTypeCode,
+                    ConsentDate: emailConsentDate,
+                    ConsentTime: emailConsentTimeZ.replace("Z", "").split(".")[0],
+                    ConsentSource: this.tenant.nebim.customer.consentSource,
+                    Email: true,
+                    FormNumber: "digital",
+                    OptIn: emailOptIn,
+                    RecipientType: 1,
+                    SMS: false
+                } : {}
+            }]
         });
 
         return {
             CustomerCode: result.CurrAccCode
         };
-    }
-
-    #hasConfirmationForm = () => {
-        return this.tenant.nebim.customer.confirmationFormTypeCode && this.tenant.nebim.customer.confirmationFormStatusCode;
-    }
-
-    #splitConsentDateTime = (iso) => {
-        const raw = iso ?? new Date().toISOString();
-        const [date, timeZ] = raw.split("T");
-        return [date, (timeZ ?? "").replace("Z", "").split(".")[0]];
-    }
-
-    #buildOptInOptOutStatusIntegrator = ({ consentDate, consentTime, optIn, isEmail }) => {
-        if (!this.#hasConfirmationForm()) return {};
-
-        return {
-            Call: !isEmail,
-            CompanyBrandCode: "",
-            ConfirmationFormStatusCode: this.tenant.nebim.customer.confirmationFormStatusCode,
-            ConfirmationFormTypeCode: this.tenant.nebim.customer.confirmationFormTypeCode,
-            ConsentDate: consentDate,
-            ConsentTime: consentTime,
-            ConsentSource: this.tenant.nebim.customer.consentSource,
-            Email: isEmail,
-            FormNumber: "digital",
-            OptIn: optIn,
-            RecipientType: 1,
-            SMS: !isEmail
-        };
-    }
-
-    #buildCommunications = (customer) => {
-        const nowIso = new Date().toISOString();
-        const [emailConsentDate, emailConsentTime] = this.#splitConsentDateTime(customer?.consents?.email?.date ?? nowIso);
-        const [gsmConsentDate, gsmConsentTime] = this.#splitConsentDateTime(customer?.consents?.gsm?.date ?? nowIso);
-
-        return [
-            {
-                CommunicationTypeCode: "3",
-                CommAddress: customer.email,
-                OptInOptOutStatusIntegrator: this.#buildOptInOptOutStatusIntegrator({
-                    consentDate: emailConsentDate,
-                    consentTime: emailConsentTime,
-                    optIn: customer?.consents?.email?.is_opt_in ?? false,
-                    isEmail: true
-                })
-            },
-            {
-                CommunicationTypeCode: this.tenant.nebim.customer.phoneType,
-                CommAddress: customer.phone,
-                OptInOptOutStatusIntegrator: this.#buildOptInOptOutStatusIntegrator({
-                    consentDate: gsmConsentDate,
-                    consentTime: gsmConsentTime,
-                    optIn: customer?.consents?.gsm?.is_opt_in ?? false,
-                    isEmail: false
-                })
-            }
-        ];
     }
 
     #updateCustomer = async (nebimCustomer, { address, is_receiver_not_customer }) => {

--- a/controllers/ShopifyNebimCustomerController.js
+++ b/controllers/ShopifyNebimCustomerController.js
@@ -36,6 +36,14 @@ export default new class ShopifyNebimCustomerController extends CoreController {
             });
         }
 
+        if (result.skipped) {
+            return this.response(res, {
+                status: HttpStatusCodes.BAD_REQUEST,
+                info: result.reason,
+                content: result
+            });
+        }
+
         return this.response(res, {
             status: HttpStatusCodes.SUCCESS,
             content: result

--- a/tests/business/nebim/CustomerBusiness.test.js
+++ b/tests/business/nebim/CustomerBusiness.test.js
@@ -557,6 +557,19 @@ describe('NebimCustomerBusiness', () => {
       });
     });
 
+    it('should skip post when consent date is missing', async () => {
+      mockApi.runProcReturnSingle.mockResolvedValue({ CustomerCode: 'CUST001' });
+      mockApi.getModel.mockResolvedValue({ CurrAccCode: 'CUST001' });
+
+      const result = await business.updateConsent({
+        email: 'test@example.com',
+        consents: { email: { is_opt_in: true } },
+      }, 'email');
+
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(result).toEqual({ skipped: true, reason: 'missing_consent_date' });
+    });
+
     it('should return null when customer is not in Nebim', async () => {
       mockApi.runProcReturnSingle.mockResolvedValue({});
 

--- a/tests/business/nebim/CustomerBusiness.test.js
+++ b/tests/business/nebim/CustomerBusiness.test.js
@@ -502,7 +502,13 @@ describe('NebimCustomerBusiness', () => {
 
     it('should post email consent as Communications[0]', async () => {
       mockApi.runProcReturnSingle.mockResolvedValue({ CustomerCode: 'CUST001' });
-      mockApi.getModel.mockResolvedValue({ CurrAccCode: 'CUST001' });
+      mockApi.getModel.mockResolvedValue({
+        CurrAccCode: 'CUST001',
+        Communications: [
+          { CommunicationTypeCode: '1', CommunicationID: 'phone-id' },
+          { CommunicationTypeCode: '3', CommunicationID: 'email-id' },
+        ],
+      });
       mockApi.post.mockResolvedValue({ CurrAccCode: 'CUST001' });
 
       const result = await business.updateConsent(customer, 'email');
@@ -513,7 +519,7 @@ describe('NebimCustomerBusiness', () => {
         Communications: [
           expect.objectContaining({
             CommunicationTypeCode: '3',
-            CommAddress: 'test@example.com',
+            CommunicationID: 'email-id',
             OptInOptOutStatusIntegrator: expect.objectContaining({
               Email: true,
               SMS: false,
@@ -531,7 +537,13 @@ describe('NebimCustomerBusiness', () => {
 
     it('should post phone consent as Communications[1] from the built array', async () => {
       mockApi.runProcReturnSingle.mockResolvedValue({ CustomerCode: 'CUST001' });
-      mockApi.getModel.mockResolvedValue({ CurrAccCode: 'CUST001' });
+      mockApi.getModel.mockResolvedValue({
+        CurrAccCode: 'CUST001',
+        Communications: [
+          { CommunicationTypeCode: '1', CommunicationID: 'phone-id' },
+          { CommunicationTypeCode: '3', CommunicationID: 'email-id' },
+        ],
+      });
       mockApi.post.mockResolvedValue({ CurrAccCode: 'CUST001' });
 
       await business.updateConsent(customer, 'gsm');
@@ -542,7 +554,7 @@ describe('NebimCustomerBusiness', () => {
         Communications: [
           expect.objectContaining({
             CommunicationTypeCode: '1',
-            CommAddress: '5551234567',
+            CommunicationID: 'phone-id',
             OptInOptOutStatusIntegrator: expect.objectContaining({
               Email: false,
               SMS: true,

--- a/tests/controllers/ShopifyNebimCustomerController.test.js
+++ b/tests/controllers/ShopifyNebimCustomerController.test.js
@@ -99,6 +99,18 @@ describe('ShopifyNebimCustomerController', () => {
       });
     });
 
+    it('should return bad request when consent date is missing', async () => {
+      mockCustomerBusiness.updateConsent.mockResolvedValue({ skipped: true, reason: 'missing_consent_date' });
+
+      await ShopifyNebimCustomerController.updateConsent(mockReq, mockRes);
+
+      expect(mockCoreController.response).toHaveBeenCalledWith(mockRes, {
+        status: HttpStatusCodes.BAD_REQUEST,
+        info: 'missing_consent_date',
+        content: { skipped: true, reason: 'missing_consent_date' },
+      });
+    });
+
     it('should return not found when customer does not exist in Nebim', async () => {
       mockCustomerBusiness.updateConsent.mockResolvedValue(null);
 


### PR DESCRIPTION
## Summary
- Fill the `updateConsent` stub: find the customer, post `ModelType: 3` + `CurrAccCode` with the same `Communications` shape as `#createCustomer` (email `CommunicationTypeCode: "3"`, phone = tenant `phoneType`).
- `/consent/email` posts only the email row; `/consent/gsm` posts only the phone row. Missing channel date skips the Integrator post (`missing_consent_date`) and the controller returns `BAD_REQUEST` — no `nowIso` on webhook updates.
- Customer not in Nebim → `null` → HTTP 404 (config-api maps this to Shopify 200).

## Test plan
- [ ] `tests/business/nebim/CustomerBusiness.test.js` and `tests/controllers/ShopifyNebimCustomerController.test.js`
- [ ] Email consent post: OptIn / ConsentDate / ConsentTime match Shopify `consent_updated_at`
- [ ] GSM consent post uses tenant `phoneType`
- [ ] Missing date: no Integrator `post`, HTTP 400
- [ ] Unknown customer: HTTP 404

## Risks
- `#updateCustomer` (order path) still does not write consent; marketing opt-in changes go through this endpoint / Shopify webhooks only. First-time Nebim customer still gets consent on `#createCustomer` from the order.
- No `CommunicationID` and no compare of incoming date vs existing Nebim consent (tracked in Gonextso/nebim-integration-app#4 / #5).
- Empty confirmation form codes still send `OptInOptOutStatusIntegrator: {}` (app#8).

Made with [Cursor](https://cursor.com)