### PR TITLE
feat: sync and audit customer consents

### DIFF
--- a/apis/NebimV3IntegratorAPI.js
+++ b/apis/NebimV3IntegratorAPI.js
@@ -112,13 +112,20 @@ export default class NebimV3IntegratorAPI extends CoreAPI {
             "Content-Type": "application/json"
         });
 
-        if (data instanceof Error) this.throws(data.message);
+        // Preserve the HTTP error (including response status/body) so legal
+        // consent audit records can store the target system's raw response.
+        if (data instanceof Error) throw data;
 
         if (!data || typeof data !== "object") {
             this.throws("Nebim V3 Integrator returned invalid response");
         }
 
-        if (data["StatusCode"] >= HttpStatusCodes.BAD_REQUEST.code) this.throws(data["ExceptionMessage"]);
+        if (data["StatusCode"] >= HttpStatusCodes.BAD_REQUEST.code) {
+            const error = new Error(data["ExceptionMessage"] || "Nebim V3 Integrator request failed");
+            error.data = data;
+            error.status = data["StatusCode"];
+            throw error;
+        }
 
         return data;
     }

--- a/apis/ShopifyGqlAPI.js
+++ b/apis/ShopifyGqlAPI.js
@@ -22,6 +22,11 @@ export default class ShopifyGqlAPI extends CoreAPI {
                 }
             });
 
+            // Keep the original HTTP error intact for callers that persist the
+            // target response in the consent audit trail.
+            if (response instanceof Error) throw response;
+            if (!response?.data) throw new Error('Shopify returned an empty GraphQL response');
+
             const data = response.data;
             const errors = data?.errors;
             const isThrottled = Array.isArray(errors) && errors.some(err => err?.extensions?.code === "THROTTLED");

--- a/business/ConsentAuditBusiness.js
+++ b/business/ConsentAuditBusiness.js
@@ -1,0 +1,76 @@
+import CoreClass from '../core/CoreClass.js';
+import CLSHelper from '../helpers/CLSHelper.js';
+import StringHelper from '../helpers/StringHelper.js';
+import CustomerConsentTransferLog from '../models/db/postgres/CustomerConsentTransferLog.js';
+
+function serializeRaw(value) {
+  if (value === undefined) return null;
+  if (typeof value === 'string') return value;
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export default class ConsentAuditBusiness extends CoreClass {
+  constructor(tenant, context = {}) {
+    super(tenant);
+    this.flowId = context.flowId || StringHelper.generateUUID();
+    this.sequenceNo = 0;
+    this.sourceSystem = context.sourceSystem;
+    this.targetSystem = context.targetSystem;
+    this.triggerType = context.triggerType;
+    this.sourceEventId = context.sourceEventId || null;
+    this.sourcePayloadRaw = serializeRaw(context.sourcePayloadRaw);
+  }
+
+  execute = async (metadata, targetRequest, executor) => {
+    this.sequenceNo += 1;
+    const pending = await CustomerConsentTransferLog.createPending({
+      flowId: this.flowId,
+      sequenceNo: this.sequenceNo,
+      tenantId: this.tenant.id || this.tenant._id,
+      tenantName: this.tenant.name || null,
+      shopDomain: this.tenant.shopify?.domain || null,
+      sourceSystem: this.sourceSystem,
+      targetSystem: this.targetSystem,
+      triggerType: this.triggerType,
+      operation: metadata.operation,
+      channel: metadata.channel || null,
+      sourceEventId: metadata.sourceEventId || this.sourceEventId,
+      sourceCustomerRef: metadata.sourceCustomerRef || null,
+      targetCustomerRef: metadata.targetCustomerRef || null,
+      consentState: metadata.consentState || null,
+      consentUpdatedAt: metadata.consentUpdatedAt ? new Date(metadata.consentUpdatedAt) : null,
+      sourcePayloadRaw: serializeRaw(metadata.sourcePayloadRaw ?? this.sourcePayloadRaw),
+      targetRequestRaw: serializeRaw(targetRequest),
+      traceId: CLSHelper.get('traceId') || null,
+    });
+
+    try {
+      const result = await executor();
+      await CustomerConsentTransferLog.complete(pending.id, {
+        status: metadata.successStatus || 'SUCCESS',
+        targetCustomerRef: metadata.resolveTargetCustomerRef?.(result) || metadata.targetCustomerRef || null,
+        targetHttpStatus: metadata.resolveHttpStatus?.(result) || 200,
+        targetResponseRaw: serializeRaw(result),
+      });
+      return result;
+    } catch (error) {
+      const response = error?.response?.data ?? error?.data ?? {
+        name: error?.name,
+        message: error?.message || String(error),
+      };
+      await CustomerConsentTransferLog.complete(pending.id, {
+        status: 'FAILED',
+        targetHttpStatus: error?.response?.status || error?.status || 0,
+        targetResponseRaw: serializeRaw(response),
+        errorCode: error?.code || null,
+        errorMessage: error?.message || String(error),
+      });
+      throw error;
+    }
+  };
+}

--- a/business/CustomerConsentSyncBusiness.js
+++ b/business/CustomerConsentSyncBusiness.js
@@ -1,0 +1,226 @@
+import { createHash } from 'node:crypto';
+import CoreClass from '../core/CoreClass.js';
+import NebimV3IntegratorAPI from '../apis/NebimV3IntegratorAPI.js';
+import ShopifyGqlAPI from '../apis/ShopifyGqlAPI.js';
+import ConsentAuditBusiness from './ConsentAuditBusiness.js';
+import customerQueries from '../models/shopify/queries/customer.js';
+import customerMutations from '../models/shopify/mutations/customer.js';
+
+function asBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value === 1;
+  return ['1', 'true', 'yes'].includes(String(value || '').toLowerCase());
+}
+
+function normalizePhone(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  if (raw.startsWith('+')) return `+${raw.slice(1).replace(/\D/g, '')}`;
+
+  const digits = raw.replace(/\D/g, '');
+  if (digits.length === 11 && digits.startsWith('0')) return `+90${digits.slice(1)}`;
+  if (digits.length === 10) return `+90${digits}`;
+  if (digits.startsWith('90')) return `+${digits}`;
+  return digits;
+}
+
+function escapeSearchValue(value) {
+  return String(value).replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}
+
+export default class CustomerConsentSyncBusiness extends CoreClass {
+  constructor(tenant, context = {}) {
+    super(tenant);
+    this.nebimAPI = new NebimV3IntegratorAPI(tenant);
+    this.shopifyAPI = new ShopifyGqlAPI(tenant);
+    this.audit = new ConsentAuditBusiness(tenant, {
+      sourceSystem: 'NEBIM',
+      targetSystem: 'SHOPIFY',
+      triggerType: 'CRON',
+      ...context,
+    });
+  }
+
+  sync = async (startDate) => {
+    if (!this.tenant.nebim?.host || !this.tenant.nebim?.user || !this.tenant.nebim?.userGroup) {
+      this.throws('Nebim connection settings are incomplete', true);
+    }
+    if (!this.tenant.shopify?.decyrptedApiKey) {
+      this.throws('Shopify access token is missing', true);
+    }
+
+    const rows = await this.nebimAPI.runProc(
+      this.tenant.nebim.procNames.customer.concents,
+      { Date: startDate },
+    );
+    if (!Array.isArray(rows)) this.throws('Customer consent procedure must return an array');
+
+    const summary = {
+      received: rows.length,
+      updated: 0,
+      notFound: 0,
+      ambiguous: 0,
+      skipped: 0,
+      failed: 0,
+    };
+
+    for (const row of this.#latestRows(rows)) {
+      const channel = this.#resolveChannel(row);
+      if (!channel) {
+        summary.skipped += 1;
+        continue;
+      }
+
+      try {
+        const customer = await this.#findCustomer(row, channel);
+        if (customer.status === 'not_found') {
+          summary.notFound += 1;
+          continue;
+        }
+        if (customer.status === 'ambiguous') {
+          summary.ambiguous += 1;
+          continue;
+        }
+
+        await this.#updateConsent(customer.node, row, channel);
+        summary.updated += 1;
+      } catch (error) {
+        summary.failed += 1;
+        this.logger.error(error);
+      }
+    }
+
+    if (summary.failed > 0) {
+      const error = new Error(`Customer consent sync completed with ${summary.failed} failed row(s)`);
+      error.summary = summary;
+      throw error;
+    }
+
+    return summary;
+  };
+
+  #latestRows = (rows) => {
+    const latest = new Map();
+    for (const row of rows) {
+      const key = `${String(row?.CommunicationTypeCode || '').trim()}:${String(row?.CommAddress || '').trim().toLowerCase()}`;
+      const current = latest.get(key);
+      const rowDate = new Date(row?.LastUpdatedDate || 0).getTime();
+      const currentDate = new Date(current?.LastUpdatedDate || 0).getTime();
+      if (!current || rowDate >= currentDate) latest.set(key, row);
+    }
+    return latest.values();
+  };
+
+  #resolveChannel = (row) => {
+    const type = String(row?.CommunicationTypeCode || '').trim();
+    if (type === '3' && asBoolean(row?.Email)) return 'EMAIL';
+    if (type === String(this.tenant.nebim.customer.phoneType) && asBoolean(row?.SMS)) return 'SMS';
+    return null;
+  };
+
+  #sourceEventId = (row) => createHash('sha256')
+    .update([
+      row?.CurrAccCode,
+      row?.CommunicationTypeCode,
+      row?.CommAddress,
+      row?.CanSendAdvert,
+      row?.LastUpdatedDate,
+    ].join('|'))
+    .digest('hex');
+
+  #metadata = (row, channel, operation) => ({
+    operation,
+    channel,
+    sourceEventId: this.#sourceEventId(row),
+    sourceCustomerRef: row?.CurrAccCode ? String(row.CurrAccCode) : null,
+    consentState: asBoolean(row?.CanSendAdvert) ? 'SUBSCRIBED' : 'UNSUBSCRIBED',
+    consentUpdatedAt: row?.LastUpdatedDate || null,
+    sourcePayloadRaw: row,
+  });
+
+  #queryShopify = async (query, variables, userErrorPath) => {
+    const response = await this.shopifyAPI.query(query, variables);
+    if (response instanceof Error) throw response;
+    if (!response) throw new Error('Shopify returned an empty GraphQL response');
+    const userErrors = userErrorPath?.(response) || [];
+    if (response?.errors?.length || userErrors.length) {
+      const error = new Error('Shopify GraphQL request failed');
+      error.data = response;
+      throw error;
+    }
+    return response;
+  };
+
+  #findCustomer = async (row, channel) => {
+    const contact = channel === 'EMAIL'
+      ? String(row.CommAddress || '').trim().toLowerCase()
+      : normalizePhone(row.CommAddress);
+    if (!contact) return { status: 'not_found' };
+
+    const search = channel === 'EMAIL'
+      ? `email:"${escapeSearchValue(contact)}"`
+      : `phone:${escapeSearchValue(contact)}`;
+    const request = { query: search };
+    const response = await this.audit.execute(
+      this.#metadata(row, channel, 'FIND_CUSTOMER'),
+      request,
+      () => this.#queryShopify(customerQueries.findByContact, request),
+    );
+    const nodes = response?.data?.customers?.nodes || [];
+    const exact = nodes.filter((node) => channel === 'EMAIL'
+      ? String(node.email || '').trim().toLowerCase() === contact
+      : normalizePhone(node.phone) === contact);
+
+    if (exact.length === 0) return { status: 'not_found' };
+    if (exact.length > 1) return { status: 'ambiguous' };
+    return { status: 'found', node: exact[0] };
+  };
+
+  #updateConsent = async (customer, row, channel) => {
+    const marketingConsent = {
+      marketingState: asBoolean(row.CanSendAdvert) ? 'SUBSCRIBED' : 'UNSUBSCRIBED',
+      marketingOptInLevel: 'SINGLE_OPT_IN',
+      consentUpdatedAt: new Date(row.LastUpdatedDate).toISOString(),
+    };
+
+    if (channel === 'EMAIL') {
+      const request = {
+        input: {
+          customerId: customer.id,
+          emailMarketingConsent: marketingConsent,
+        },
+      };
+      return this.audit.execute(
+        {
+          ...this.#metadata(row, channel, 'UPDATE_EMAIL_CONSENT'),
+          targetCustomerRef: customer.id,
+        },
+        request,
+        () => this.#queryShopify(
+          customerMutations.updateEmailConsent,
+          request,
+          (response) => response?.data?.customerEmailMarketingConsentUpdate?.userErrors || [],
+        ),
+      );
+    }
+
+    const request = {
+      input: {
+        customerId: customer.id,
+        smsMarketingConsent: marketingConsent,
+      },
+    };
+    return this.audit.execute(
+      {
+        ...this.#metadata(row, channel, 'UPDATE_SMS_CONSENT'),
+        targetCustomerRef: customer.id,
+      },
+      request,
+      () => this.#queryShopify(
+        customerMutations.updateSmsConsent,
+        request,
+        (response) => response?.data?.customerSmsMarketingConsentUpdate?.userErrors || [],
+      ),
+    );
+  };
+}

--- a/business/nebim/CustomerBusiness.js
+++ b/business/nebim/CustomerBusiness.js
@@ -2,6 +2,7 @@ import CoreClass from "../../core/CoreClass.js";
 import NebimV3IntegratorAPI from "../../apis/NebimV3IntegratorAPI.js";
 import NebimCache from "../../cache/NebimCache.js";
 import CacheFields from "../../enums/CacheFields.js";
+import ConsentAuditBusiness from "../ConsentAuditBusiness.js";
 
 const SETUP_TEST_EMAIL = "support@gonextso.com";
 const SETUP_TEST_PHONE = "05555555555";
@@ -193,8 +194,44 @@ export default class NebimCustomerClass extends CoreClass {
         };
     }
 
-    updateConsent = async (customer, communicationType) => {
-        const nebimCustomer = await this.fetchCustomer(customer);
+    updateConsent = async (customer, communicationType, auditContext = null) => {
+        const audit = auditContext ? new ConsentAuditBusiness(this.tenant, {
+            sourceSystem: "SHOPIFY",
+            targetSystem: "NEBIM",
+            triggerType: "WEBHOOK",
+            ...auditContext,
+        }) : null;
+
+        const findRequest = {
+            Email: customer.email ?? "",
+            Phone: customer.phone ?? "",
+            PhoneType: this.tenant.nebim.customer.phoneType,
+        };
+        const shortInfo = audit
+            ? await audit.execute(
+                {
+                    operation: "FIND_CUSTOMER",
+                    channel: communicationType === "gsm" ? "SMS" : "EMAIL",
+                    sourceCustomerRef: customer.email || customer.phone || null,
+                },
+                { ProcName: this.tenant.nebim.procNames.customer.check, ...findRequest },
+                () => this.api.runProcReturnSingle(this.tenant.nebim.procNames.customer.check, findRequest),
+            )
+            : null;
+        const nebimCustomer = audit
+            ? (shortInfo?.CustomerCode
+                ? await audit.execute(
+                    {
+                        operation: "GET_CUSTOMER_MODEL",
+                        channel: communicationType === "gsm" ? "SMS" : "EMAIL",
+                        sourceCustomerRef: customer.email || customer.phone || null,
+                        targetCustomerRef: shortInfo.CustomerCode,
+                    },
+                    { ModelType: 3, CurrAccCode: shortInfo.CustomerCode },
+                    () => this.api.getModel("customer", shortInfo.CustomerCode),
+                )
+                : null)
+            : await this.fetchCustomer(customer);
 
         if (!nebimCustomer) return null;
 
@@ -208,7 +245,7 @@ export default class NebimCustomerClass extends CoreClass {
         const [ emailConsentDate, emailConsentTimeZ ] = (emailConsentRaw ?? "").split("T");
         const [ gsmConsentDate, gsmConsentTimeZ ] = (gsmConsentRaw ?? "").split("T");
 
-        const result = await this.api.post({
+        const request = {
             ModelType: 3,
             CurrAccCode: nebimCustomer.CurrAccCode,
             Communications: communicationType === "gsm" ? [{
@@ -246,7 +283,23 @@ export default class NebimCustomerClass extends CoreClass {
                     SMS: false
                 } : {}
             }]
-        });
+        };
+        const result = audit
+            ? await audit.execute(
+                {
+                    operation: communicationType === "gsm" ? "UPDATE_SMS_CONSENT" : "UPDATE_EMAIL_CONSENT",
+                    channel: communicationType === "gsm" ? "SMS" : "EMAIL",
+                    sourceCustomerRef: customer.email || customer.phone || null,
+                    targetCustomerRef: nebimCustomer.CurrAccCode,
+                    consentState: communicationType === "gsm"
+                        ? (gsmOptIn ? "SUBSCRIBED" : "UNSUBSCRIBED")
+                        : (emailOptIn ? "SUBSCRIBED" : "UNSUBSCRIBED"),
+                    consentUpdatedAt: consentRaw,
+                },
+                request,
+                () => this.api.post(request),
+            )
+            : await this.api.post(request);
 
         return {
             CustomerCode: result.CurrAccCode

--- a/controllers/ShopifyNebimCustomerController.js
+++ b/controllers/ShopifyNebimCustomerController.js
@@ -1,6 +1,7 @@
 import CoreController from "../core/CoreControler.js";
 import HttpStatusCodes from "../enums/HttpStatusCodes.js";
 import NebimCustomerBusiness from "../business/nebim/CustomerBusiness.js";
+import CustomerConsentSyncBusiness from "../business/CustomerConsentSyncBusiness.js";
 
 export default new class ShopifyNebimCustomerController extends CoreController {
     constructor() {
@@ -27,7 +28,10 @@ export default new class ShopifyNebimCustomerController extends CoreController {
         }
 
         const customerBusiness = new NebimCustomerBusiness(req.tenant);
-        const result = await customerBusiness.updateConsent(customer, communitaionType);
+        const result = await customerBusiness.updateConsent(customer, communitaionType, {
+            sourceEventId: req.body?.audit?.sourceEventId || req.get?.("x-source-event-id") || null,
+            sourcePayloadRaw: req.body?.audit?.sourcePayload || customer,
+        });
 
         if (!result) {
             return this.response(res, {
@@ -47,6 +51,16 @@ export default new class ShopifyNebimCustomerController extends CoreController {
         return this.response(res, {
             status: HttpStatusCodes.SUCCESS,
             content: result
+        });
+    }
+
+    syncConsents = async (req, res) => {
+        const business = new CustomerConsentSyncBusiness(req.tenant);
+        const summary = await business.sync(req.startDate);
+
+        return this.response(res, {
+            status: HttpStatusCodes.SUCCESS,
+            content: summary,
         });
     }
 }

--- a/models/db/postgres/CustomerConsentTransferLog.js
+++ b/models/db/postgres/CustomerConsentTransferLog.js
@@ -1,0 +1,24 @@
+import prisma from '../../../builders/database/prismaBuilder.js';
+
+class CustomerConsentTransferLogModel {
+  async createPending(data) {
+    return prisma.customerConsentTransferLog.create({
+      data: {
+        ...data,
+        status: 'PENDING',
+      },
+    });
+  }
+
+  async complete(id, data) {
+    return prisma.customerConsentTransferLog.update({
+      where: { id },
+      data: {
+        ...data,
+        completedAt: new Date(),
+      },
+    });
+  }
+}
+
+export default new CustomerConsentTransferLogModel();

--- a/models/db/postgres/Tenant.js
+++ b/models/db/postgres/Tenant.js
@@ -106,6 +106,7 @@ class TenantModel {
             procGetStoreInfo: 'sp_GO_GetStoreInfo',
             procGetStoreInfo: 'sp_GO_GetStoreInfo',
             procCustomerCheck: 'sp_GO_GetCustomer',
+            procCustomerConcents: 'sp_GO_GetCustomerConcents',
             procOrderStatus: 'sp_GO_OrderStatus',
             procDefaultsAddressCodes: 'sp_GO_GetAddressList',
           },
@@ -151,6 +152,9 @@ class TenantModel {
             nebimOrderStatusInterval: '0 * * * *',
             nebimOrderStatusStartDate: moment().subtract(1, 'days').toDate(),
             nebimOrderStatusIsActive: false,
+            nebimCustomerConcentsInterval: '0 0 * * *',
+            nebimCustomerConcentsStartDate: moment().subtract(1, 'days').toDate(),
+            nebimCustomerConcentsIsActive: true,
             nebimProductFindInStoreInterval: '*/30 * * * *',
             nebimProductFindInStoreStartDate: moment().subtract(30, 'minutes').toDate(),
             nebimProductFindInStoreIsActive: false,
@@ -434,6 +438,13 @@ class TenantModel {
             contentStartDate: tenant.schedules?.nebimProductMarketContentStartDate?.toISOString() || null,
           },
         },
+        customer: {
+          concents: {
+            interval: tenant.schedules?.nebimCustomerConcentsInterval || '0 0 * * *',
+            startDate: tenant.schedules?.nebimCustomerConcentsStartDate?.toISOString() || null,
+            isActive: tenant.schedules?.nebimCustomerConcentsIsActive ?? true,
+          },
+        },
         order: {
           create_and_cancel: {
             interval: tenant.schedules?.nebimOrderCreateCancelInterval || '*/30 * * * *',
@@ -510,6 +521,7 @@ class TenantModel {
         },
         customer: {
           check: tenant.nebim?.procCustomerCheck || 'sp_GO_GetCustomer',
+          concents: tenant.nebim?.procCustomerConcents || 'sp_GO_GetCustomerConcents',
         },
         order: {
           status: tenant.nebim?.procOrderStatus || 'sp_GO_OrderStatus',
@@ -536,4 +548,3 @@ class TenantModel {
 
 // Export singleton instance
 export default new TenantModel();
-

--- a/models/shopify/mutations/customer.js
+++ b/models/shopify/mutations/customer.js
@@ -1,0 +1,36 @@
+export default {
+  updateEmailConsent: `
+mutation UpdateCustomerEmailConsent($input: CustomerEmailMarketingConsentUpdateInput!) {
+  customerEmailMarketingConsentUpdate(input: $input) {
+    customer {
+      id
+      email
+      emailMarketingConsent {
+        marketingState
+        consentUpdatedAt
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`,
+  updateSmsConsent: `
+mutation UpdateCustomerSmsConsent($input: CustomerSmsMarketingConsentUpdateInput!) {
+  customerSmsMarketingConsentUpdate(input: $input) {
+    customer {
+      id
+      phone
+      smsMarketingConsent {
+        marketingState
+        consentUpdatedAt
+      }
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}`,
+};

--- a/models/shopify/queries/customer.js
+++ b/models/shopify/queries/customer.js
@@ -1,0 +1,12 @@
+export default {
+  findByContact: `
+query FindCustomerByContact($query: String!) {
+  customers(first: 2, query: $query) {
+    nodes {
+      id
+      email
+      phone
+    }
+  }
+}`,
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  schemas  = ["tenants", "billings", "sync", "logs", "auths", "defaults", "schedules", "products"]
+  schemas  = ["tenants", "billings", "sync", "logs", "audit", "auths", "defaults", "schedules", "products"]
 }
 
 // Enums
@@ -49,104 +49,105 @@ model TenantInfo {
   updatedAt   DateTime @updatedAt @map("updated_at")
 
   // Relations
-  shopify     TenantShopify?
-  nebim       TenantNebim?
-  shopifyAuth AuthShopify?
-  nebimAuth   AuthNebim?
-  pricing     PricingInfo?
-  schedules   ScheduleTenant?
-  syncBatches SyncBatch[]
-  failedOrders SyncFailedOrder[]
-  successOrders SyncSuccessOrder[]
-  requestLogs RequestLog[]
+  shopify              TenantShopify?
+  nebim                TenantNebim?
+  shopifyAuth          AuthShopify?
+  nebimAuth            AuthNebim?
+  pricing              PricingInfo?
+  schedules            ScheduleTenant?
+  syncBatches          SyncBatch[]
+  failedOrders         SyncFailedOrder[]
+  successOrders        SyncSuccessOrder[]
+  requestLogs          RequestLog[]
   productSyncedBatches ProductSyncedBatch[]
-  syncedBarcodes SyncedBarcode[]
+  syncedBarcodes       SyncedBarcode[]
 
   @@map("info")
   @@schema("tenants")
 }
 
 model TenantShopify {
-  id                    String   @id @default(uuid())
-  tenantId              String   @unique @map("tenant_id")
-  name                  String?
-  domain                String?  @unique
-  shopId                String?  @unique @map("shop_id")
-  customerEmail         String?  @map("customer_email")
-  isInventoryTracking   Boolean  @default(true) @map("is_inventory_tracking")
-  isColorOptionFirst    Boolean  @default(true) @map("is_color_option_first")
-  isEnterprise          Boolean  @default(false) @map("is_enterprise")
-  isShopifyPlus         Boolean  @default(false) @map("is_shopify_plus")
-  isActive              Boolean  @default(true) @map("is_active")
-  currencyCode          String?  @map("currency_code")
-  countryCode           String?  @map("country_code")
-  skuFieldsNebim        String[] @map("sku_fields_nebim")
-  skuFieldsSeparator    String   @default("-") @map("sku_fields_separator")
-  createdAt             DateTime @default(now()) @map("created_at")
-  updatedAt             DateTime @updatedAt @map("updated_at")
+  id                  String   @id @default(uuid())
+  tenantId            String   @unique @map("tenant_id")
+  name                String?
+  domain              String?  @unique
+  shopId              String?  @unique @map("shop_id")
+  customerEmail       String?  @map("customer_email")
+  isInventoryTracking Boolean  @default(true) @map("is_inventory_tracking")
+  isColorOptionFirst  Boolean  @default(true) @map("is_color_option_first")
+  isEnterprise        Boolean  @default(false) @map("is_enterprise")
+  isShopifyPlus       Boolean  @default(false) @map("is_shopify_plus")
+  isActive            Boolean  @default(true) @map("is_active")
+  currencyCode        String?  @map("currency_code")
+  countryCode         String?  @map("country_code")
+  skuFieldsNebim      String[] @map("sku_fields_nebim")
+  skuFieldsSeparator  String   @default("-") @map("sku_fields_separator")
+  createdAt           DateTime @default(now()) @map("created_at")
+  updatedAt           DateTime @updatedAt @map("updated_at")
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  @@map("shopify")
-  @@schema("tenants")
   @@index([tenantId])
   @@index([domain])
   @@index([shopId])
+  @@map("shopify")
+  @@schema("tenants")
 }
 
 model TenantNebim {
-  id                            String   @id @default(uuid())
-  tenantId                      String   @unique @map("tenant_id")
-  host                          String?
-  user                          String?
-  userGroup                     String?  @map("user_group")
-  salesUrl                      String?  @map("sales_url")
-  isActive                      Boolean  @default(true) @map("is_active")
-  blockProductGenerationWhenOff Boolean  @default(false) @map("block_product_generation_when_off")
-  cargoItemCode                 String?  @map("cargo_item_code")
-  isCargoService                Boolean  @default(false) @map("is_cargo_service")
-  productCategoryKeysFrom       String[] @map("product_category_keys_from")
-  productBarcodeTypeCode        String   @default("EAN13") @map("product_barcode_type_code")
-  productPriceSellCode          String?  @map("product_price_sell_code")
-  productPriceCompareCode       String?  @map("product_price_compare_code")
-  productResponsibilityAreaCode String?  @map("product_responsibility_area_code")
-  productIsColorBased           Boolean  @default(false) @map("product_is_color_based")
-  productUseInternetOnVariant   Boolean  @default(false) @map("product_use_internet_on_variant")
-  productUsedSeparatorOnColorAndItem String? @map("product_used_separator_on_color_and_item")
-  productUsedSeparatorOnColorAndItemDescriptions String? @map("product_used_separator_on_color_and_item_descriptions")
-  customerPhoneType             String   @default("7") @map("customer_phone_type")
-  customerAddressType           String   @default("1") @map("customer_address_type")
-  customerConfirmationFormTypeCode    String?  @map("customer_confirmation_form_type_code")
-  customerConfirmationFormStatusCode String?  @map("customer_confirmation_form_status_code")
-  customerConsentSource         String   @default("HS_WEB") @map("customer_consent_source")
-  customerInactivationReasonCode String? @map("customer_inactivation_reason_code")
-  orderDeliveryCompany          String?  @map("order_delivery_company")
-  orderPosTerminalId            Int      @default(1) @map("order_pos_terminal_id")
-  orderCreditCardType           String?  @map("order_credit_card_type")
-  orderOffice                   String?  @map("order_office")
-  orderStore                    String?  @map("order_store")
-  orderCompany                  String?  @map("order_company")
-  orderWarehouse                String?  @map("order_warehouse")
-  orderCancelReason             String?  @map("order_cancel_reason")
-  orderIsMicroExport            Boolean  @default(false) @map("order_is_micro_export")
-  orderIncotermCode1            String?  @map("order_incoterm_code1")
-  orderIncotermCode2            String?  @map("order_incoterm_code2")
-  procProductDetails            String   @default("sp_GO_GetProductDetails") @map("proc_product_details")
-  procProductInventory          String   @default("sp_GO_GetProductInventory") @map("proc_product_inventory")
-  procProductPrice              String   @default("sp_GO_GetProductPrice") @map("proc_product_price")
-  procFindStoreInventory        String   @default("sp_GO_FindInStore") @map("proc_find_store_inventory")
-  procGetStoreInfo              String   @default("sp_GO_GetStoreInfo") @map("proc_get_store_info")
-  procCustomerCheck             String   @default("sp_GO_GetCustomer") @map("proc_customer_check")
-  procOrderStatus               String   @default("sp_GO_OrderStatus") @map("proc_order_status")
-  procDefaultsAddressCodes      String   @default("sp_GO_GetAddressList") @map("proc_defaults_address_codes")
-  createdAt                     DateTime @default(now()) @map("created_at")
-  updatedAt                     DateTime @updatedAt @map("updated_at")
+  id                                             String   @id @default(uuid())
+  tenantId                                       String   @unique @map("tenant_id")
+  host                                           String?
+  user                                           String?
+  userGroup                                      String?  @map("user_group")
+  salesUrl                                       String?  @map("sales_url")
+  isActive                                       Boolean  @default(true) @map("is_active")
+  blockProductGenerationWhenOff                  Boolean  @default(false) @map("block_product_generation_when_off")
+  cargoItemCode                                  String?  @map("cargo_item_code")
+  isCargoService                                 Boolean  @default(false) @map("is_cargo_service")
+  productCategoryKeysFrom                        String[] @map("product_category_keys_from")
+  productBarcodeTypeCode                         String   @default("EAN13") @map("product_barcode_type_code")
+  productPriceSellCode                           String?  @map("product_price_sell_code")
+  productPriceCompareCode                        String?  @map("product_price_compare_code")
+  productResponsibilityAreaCode                  String?  @map("product_responsibility_area_code")
+  productIsColorBased                            Boolean  @default(false) @map("product_is_color_based")
+  productUseInternetOnVariant                    Boolean  @default(false) @map("product_use_internet_on_variant")
+  productUsedSeparatorOnColorAndItem             String?  @map("product_used_separator_on_color_and_item")
+  productUsedSeparatorOnColorAndItemDescriptions String?  @map("product_used_separator_on_color_and_item_descriptions")
+  customerPhoneType                              String   @default("7") @map("customer_phone_type")
+  customerAddressType                            String   @default("1") @map("customer_address_type")
+  customerConfirmationFormTypeCode               String?  @map("customer_confirmation_form_type_code")
+  customerConfirmationFormStatusCode             String?  @map("customer_confirmation_form_status_code")
+  customerConsentSource                          String   @default("HS_WEB") @map("customer_consent_source")
+  customerInactivationReasonCode                 String?  @map("customer_inactivation_reason_code")
+  orderDeliveryCompany                           String?  @map("order_delivery_company")
+  orderPosTerminalId                             Int      @default(1) @map("order_pos_terminal_id")
+  orderCreditCardType                            String?  @map("order_credit_card_type")
+  orderOffice                                    String?  @map("order_office")
+  orderStore                                     String?  @map("order_store")
+  orderCompany                                   String?  @map("order_company")
+  orderWarehouse                                 String?  @map("order_warehouse")
+  orderCancelReason                              String?  @map("order_cancel_reason")
+  orderIsMicroExport                             Boolean  @default(false) @map("order_is_micro_export")
+  orderIncotermCode1                             String?  @map("order_incoterm_code1")
+  orderIncotermCode2                             String?  @map("order_incoterm_code2")
+  procProductDetails                             String   @default("sp_GO_GetProductDetails") @map("proc_product_details")
+  procProductInventory                           String   @default("sp_GO_GetProductInventory") @map("proc_product_inventory")
+  procProductPrice                               String   @default("sp_GO_GetProductPrice") @map("proc_product_price")
+  procFindStoreInventory                         String   @default("sp_GO_FindInStore") @map("proc_find_store_inventory")
+  procGetStoreInfo                               String   @default("sp_GO_GetStoreInfo") @map("proc_get_store_info")
+  procCustomerCheck                              String   @default("sp_GO_GetCustomer") @map("proc_customer_check")
+  procCustomerConcents                           String   @default("sp_GO_GetCustomerConcents") @map("proc_customer_concents")
+  procOrderStatus                                String   @default("sp_GO_OrderStatus") @map("proc_order_status")
+  procDefaultsAddressCodes                       String   @default("sp_GO_GetAddressList") @map("proc_defaults_address_codes")
+  createdAt                                      DateTime @default(now()) @map("created_at")
+  updatedAt                                      DateTime @updatedAt @map("updated_at")
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("nebim")
   @@schema("tenants")
-  @@index([tenantId])
 }
 
 model AuthShopify {
@@ -161,9 +162,9 @@ model AuthShopify {
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("shopify")
   @@schema("auths")
-  @@index([tenantId])
 }
 
 model AuthNebim {
@@ -178,131 +179,171 @@ model AuthNebim {
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("nebim")
   @@schema("auths")
-  @@index([tenantId])
 }
 
 model PricingInfo {
-  id                    String            @id @default(uuid())
-  tenantId              String            @unique @map("tenant_id")
-  planKey               PlanKey           @map("plan_key")
-  billingInterval       BillingInterval   @default(MONTHLY) @map("billing_interval")
-  subscriptionId        String?   @map("subscription_id")
-  subscriptionLineId    String?   @map("subscription_line_id")
-  orderLimit            Int       @default(5) @map("order_limit")
-  orderUsed             Int       @default(0) @map("order_used")
-  productDetailsLimit   Int       @default(100) @map("product_details_limit")
-  productDetailsUsed    Int       @default(0) @map("product_details_used")
-  periodStart           DateTime  @map("period_start")
-  periodEnd             DateTime  @map("period_end")
-  isBlocked             Boolean   @default(false) @map("is_blocked")
-  pendingNonce          String?   @map("pending_nonce")
-  pendingPlanKey        String?   @map("pending_plan_key")
-  createdAt             DateTime  @default(now()) @map("created_at")
-  updatedAt             DateTime  @updatedAt @map("updated_at")
+  id                  String          @id @default(uuid())
+  tenantId            String          @unique @map("tenant_id")
+  planKey             PlanKey         @map("plan_key")
+  billingInterval     BillingInterval @default(MONTHLY) @map("billing_interval")
+  subscriptionId      String?         @map("subscription_id")
+  subscriptionLineId  String?         @map("subscription_line_id")
+  orderLimit          Int             @default(5) @map("order_limit")
+  orderUsed           Int             @default(0) @map("order_used")
+  productDetailsLimit Int             @default(100) @map("product_details_limit")
+  productDetailsUsed  Int             @default(0) @map("product_details_used")
+  periodStart         DateTime        @map("period_start")
+  periodEnd           DateTime        @map("period_end")
+  isBlocked           Boolean         @default(false) @map("is_blocked")
+  pendingNonce        String?         @map("pending_nonce")
+  pendingPlanKey      String?         @map("pending_plan_key")
+  createdAt           DateTime        @default(now()) @map("created_at")
+  updatedAt           DateTime        @updatedAt @map("updated_at")
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("pricing")
   @@schema("billings")
-  @@index([tenantId])
 }
 
 model ScheduleTenant {
-  id                              String    @id @default(uuid())
-  tenantId                        String    @unique @map("tenant_id")
-  nebimProductInventoryInterval   String    @default("0 * * * *") @map("nebim_product_inventory_interval")
-  nebimProductInventoryStartDate  DateTime? @map("nebim_product_inventory_start_date")
-  nebimProductInventoryIsActive   Boolean   @default(false) @map("nebim_product_inventory_is_active")
-  nebimProductDetailsInterval     String    @default("0 0 * * *") @map("nebim_product_details_interval")
-  nebimProductDetailsStartDate    DateTime? @map("nebim_product_details_start_date")
-  nebimProductDetailsIsActive     Boolean   @default(false) @map("nebim_product_details_is_active")
-  nebimOrderCreateCancelInterval  String    @default("*/30 * * * *") @map("nebim_order_create_cancel_interval")
-  nebimOrderCreateCancelStartDate DateTime? @map("nebim_order_create_cancel_start_date")
-  nebimOrderCreateCancelIsActive  Boolean   @default(false) @map("nebim_order_create_cancel_is_active")
-  nebimOrderStatusInterval        String    @default("0 0 * * *") @map("nebim_order_status_interval")
-  nebimOrderStatusStartDate       DateTime? @map("nebim_order_status_start_date")
-  nebimOrderStatusIsActive        Boolean   @default(false) @map("nebim_order_status_is_active")
-  nebimProductFindInStoreInterval   String   @default("*/30 * * * *") @map("nebim_product_find_in_store_interval")
-  nebimProductFindInStoreStartDate  DateTime @default(now()) @map("nebim_product_find_in_store_start_date")
-  nebimProductFindInStoreIsActive   Boolean  @default(false) @map("nebim_product_find_in_store_is_active")
+  id                                 String    @id @default(uuid())
+  tenantId                           String    @unique @map("tenant_id")
+  nebimProductInventoryInterval      String    @default("0 * * * *") @map("nebim_product_inventory_interval")
+  nebimProductInventoryStartDate     DateTime? @map("nebim_product_inventory_start_date")
+  nebimProductInventoryIsActive      Boolean   @default(false) @map("nebim_product_inventory_is_active")
+  nebimProductDetailsInterval        String    @default("0 0 * * *") @map("nebim_product_details_interval")
+  nebimProductDetailsStartDate       DateTime? @map("nebim_product_details_start_date")
+  nebimProductDetailsIsActive        Boolean   @default(false) @map("nebim_product_details_is_active")
+  nebimOrderCreateCancelInterval     String    @default("*/30 * * * *") @map("nebim_order_create_cancel_interval")
+  nebimOrderCreateCancelStartDate    DateTime? @map("nebim_order_create_cancel_start_date")
+  nebimOrderCreateCancelIsActive     Boolean   @default(false) @map("nebim_order_create_cancel_is_active")
+  nebimOrderStatusInterval           String    @default("0 0 * * *") @map("nebim_order_status_interval")
+  nebimOrderStatusStartDate          DateTime? @map("nebim_order_status_start_date")
+  nebimOrderStatusIsActive           Boolean   @default(false) @map("nebim_order_status_is_active")
+  nebimCustomerConcentsInterval      String    @default("0 0 * * *") @map("nebim_customer_concents_interval")
+  nebimCustomerConcentsStartDate     DateTime? @map("nebim_customer_concents_start_date")
+  nebimCustomerConcentsIsActive      Boolean   @default(true) @map("nebim_customer_concents_is_active")
+  nebimProductFindInStoreInterval    String    @default("*/30 * * * *") @map("nebim_product_find_in_store_interval")
+  nebimProductFindInStoreStartDate   DateTime  @default(now()) @map("nebim_product_find_in_store_start_date")
+  nebimProductFindInStoreIsActive    Boolean   @default(false) @map("nebim_product_find_in_store_is_active")
   nebimProductMarketSyncInterval     String    @default("0 0 * * *") @map("nebim_product_market_sync_interval")
   nebimProductMarketSyncIsActive     Boolean   @default(false) @map("nebim_product_market_sync_is_active")
   nebimProductMarketPriceStartDate   DateTime? @map("nebim_product_market_price_start_date")
   nebimProductMarketContentStartDate DateTime? @map("nebim_product_market_content_start_date")
-  redentionLogsInterval           String    @default("0 0 * * *") @map("redention_logs_interval")
-  redentionLogsStartDate          DateTime? @map("redention_logs_start_date")
-  redentionLogsIsActive           Boolean   @default(true) @map("redention_logs_is_active")
-  createdAt                       DateTime  @default(now()) @map("created_at")
-  updatedAt                       DateTime  @updatedAt @map("updated_at")
+  redentionLogsInterval              String    @default("0 0 * * *") @map("redention_logs_interval")
+  redentionLogsStartDate             DateTime? @map("redention_logs_start_date")
+  redentionLogsIsActive              Boolean   @default(true) @map("redention_logs_is_active")
+  createdAt                          DateTime  @default(now()) @map("created_at")
+  updatedAt                          DateTime  @updatedAt @map("updated_at")
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
+  @@index([tenantId])
   @@map("tenant")
   @@schema("schedules")
-  @@index([tenantId])
+}
+
+model CustomerConsentTransferLog {
+  id                String    @id @default(uuid())
+  flowId            String    @map("flow_id")
+  sequenceNo        Int       @map("sequence_no")
+  tenantId          String    @map("tenant_id")
+  tenantName        String?   @map("tenant_name")
+  shopDomain        String?   @map("shop_domain")
+  sourceSystem      String    @map("source_system")
+  targetSystem      String    @map("target_system")
+  triggerType       String    @map("trigger_type")
+  operation         String
+  channel           String?
+  sourceEventId     String?   @map("source_event_id")
+  sourceCustomerRef String?   @map("source_customer_ref")
+  targetCustomerRef String?   @map("target_customer_ref")
+  consentState      String?   @map("consent_state")
+  consentUpdatedAt  DateTime? @map("consent_updated_at")
+  sourcePayloadRaw  String?   @map("source_payload_raw") @db.Text
+  targetRequestRaw  String?   @map("target_request_raw") @db.Text
+  targetHttpStatus  Int?      @map("target_http_status")
+  targetResponseRaw String?   @map("target_response_raw") @db.Text
+  status            String    @default("PENDING")
+  errorCode         String?   @map("error_code")
+  errorMessage      String?   @map("error_message") @db.Text
+  traceId           String?   @map("trace_id")
+  createdAt         DateTime  @default(now()) @map("created_at")
+  completedAt       DateTime? @map("completed_at")
+
+  @@unique([flowId, sequenceNo])
+  @@index([tenantId, createdAt])
+  @@index([sourceEventId])
+  @@index([traceId])
+  @@index([status])
+  @@map("customer_consent_transfer_log")
+  @@schema("audit")
 }
 
 // Sync Schema (shared with config-api)
 model SyncBatch {
-  id                              String   @id @default(uuid())
-  tenantId                        String   @map("tenant_id")
+  id                              String      @id @default(uuid())
+  tenantId                        String      @map("tenant_id")
   process                         ProcessType
-  requestStartDate                String?  @map("request_start_date")
-  requestEndDate                  String?  @map("request_end_date")
-  requestOrderNumberList          String[] @map("request_order_number_list")
+  requestStartDate                String?     @map("request_start_date")
+  requestEndDate                  String?     @map("request_end_date")
+  requestOrderNumberList          String[]    @map("request_order_number_list")
   total                           Int?
-  createOrderTotal                Int?     @map("create_order_total")
-  createOrderSuccess              Int?     @map("create_order_success")
-  createOrderError                Int?     @map("create_order_error")
-  createOrderSkippedTotal         Int?     @map("create_order_skipped_total")
-  createOrderSkippedAlreadySynced Int?     @map("create_order_skipped_already_synced")
-  createOrderSkippedFailed        Int?     @map("create_order_skipped_failed")
-  cancelOrderTotal                Int?     @map("cancel_order_total")
-  cancelOrderSuccess              Int?     @map("cancel_order_success")
-  cancelOrderError                Int?     @map("cancel_order_error")
-  cancelOrderSkippedTotal         Int?     @map("cancel_order_skipped_total")
-  cancelOrderSkippedAlreadySynced Int?     @map("cancel_order_skipped_already_synced")
-  cancelOrderSkippedFailed        Int?     @map("cancel_order_skipped_failed")
-  cancelOrderSkippedNotFound      Int?     @map("cancel_order_skipped_not_found")
-  isErrorLogExistsForBatch        Boolean  @default(false) @map("is_error_log_exists_for_batch")
-  traceId                         String   @map("trace_id")
-  createdAt                       DateTime @default(now()) @map("created_at")
+  createOrderTotal                Int?        @map("create_order_total")
+  createOrderSuccess              Int?        @map("create_order_success")
+  createOrderError                Int?        @map("create_order_error")
+  createOrderSkippedTotal         Int?        @map("create_order_skipped_total")
+  createOrderSkippedAlreadySynced Int?        @map("create_order_skipped_already_synced")
+  createOrderSkippedFailed        Int?        @map("create_order_skipped_failed")
+  cancelOrderTotal                Int?        @map("cancel_order_total")
+  cancelOrderSuccess              Int?        @map("cancel_order_success")
+  cancelOrderError                Int?        @map("cancel_order_error")
+  cancelOrderSkippedTotal         Int?        @map("cancel_order_skipped_total")
+  cancelOrderSkippedAlreadySynced Int?        @map("cancel_order_skipped_already_synced")
+  cancelOrderSkippedFailed        Int?        @map("cancel_order_skipped_failed")
+  cancelOrderSkippedNotFound      Int?        @map("cancel_order_skipped_not_found")
+  isErrorLogExistsForBatch        Boolean     @default(false) @map("is_error_log_exists_for_batch")
+  traceId                         String      @map("trace_id")
+  createdAt                       DateTime    @default(now()) @map("created_at")
 
-  tenant       TenantInfo         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  failedOrders SyncFailedOrder[]
+  tenant        TenantInfo         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  failedOrders  SyncFailedOrder[]
   successOrders SyncSuccessOrder[]
-  logs         SyncBatchLog[]
+  logs          SyncBatchLog[]
 
-  @@map("batch")
-  @@schema("sync")
   @@index([tenantId])
   @@index([traceId])
+  @@map("batch")
+  @@schema("sync")
 }
 
 model SyncFailedOrder {
-  id              String   @id @default(uuid())
-  tenantId        String   @map("tenant_id")
-  syncBatchId     String   @map("sync_batch_id")
-  shopifyOrderId  String   @map("shopify_order_id")
-  orderData       Json?    @map("order_data")
-  reason           String?
-  process          ProcessType
-  isCancelled     Boolean  @default(false) @map("is_cancelled")
-  traceId         String   @map("trace_id")
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt @map("updated_at")
+  id             String      @id @default(uuid())
+  tenantId       String      @map("tenant_id")
+  syncBatchId    String      @map("sync_batch_id")
+  shopifyOrderId String      @map("shopify_order_id")
+  orderData      Json?       @map("order_data")
+  reason         String?
+  process        ProcessType
+  isCancelled    Boolean     @default(false) @map("is_cancelled")
+  traceId        String      @map("trace_id")
+  createdAt      DateTime    @default(now()) @map("created_at")
+  updatedAt      DateTime    @updatedAt @map("updated_at")
 
-  tenant   TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  syncBatch SyncBatch @relation(fields: [syncBatchId], references: [id], onDelete: Cascade)
+  tenant    TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  syncBatch SyncBatch  @relation(fields: [syncBatchId], references: [id], onDelete: Cascade)
 
-  @@map("failed_order")
-  @@schema("sync")
   @@index([tenantId])
   @@index([syncBatchId])
   @@index([traceId])
   @@index([shopifyOrderId])
+  @@map("failed_order")
+  @@schema("sync")
 }
 
 model SyncSuccessOrder {
@@ -323,13 +364,13 @@ model SyncSuccessOrder {
   tenant    TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   syncBatch SyncBatch  @relation(fields: [syncBatchId], references: [id], onDelete: Cascade)
 
-  @@map("success_order")
-  @@schema("sync")
   @@index([tenantId])
   @@index([syncBatchId])
   @@index([traceId])
   @@index([nebimOrderId])
   @@index([shopifyOrderId])
+  @@map("success_order")
+  @@schema("sync")
 }
 
 // Logs Schema (shared with config-api, but with extra fields for integration-api)
@@ -352,46 +393,46 @@ model RequestLog {
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  @@map("request")
-  @@schema("logs")
   @@index([tenantId])
   @@index([traceId])
   @@index([transactionId])
   @@index([businessLayer])
+  @@map("request")
+  @@schema("logs")
 }
 
 // Products Schema (integration-api specific)
 model ProductSyncedBatch {
-  id                                  String   @id @default(uuid())
-  tenantId                            String   @map("tenant_id")
-  process                              String
-  requestStartDate                     String?  @map("request_start_date")
-  requestEndDate                       String?  @map("request_end_date")
-  requestProductNumberList             String[] @map("request_product_number_list")
-  total                                Int?
-  createProductTotal                   Int?     @map("create_product_total")
-  createProductSuccess                 Int?     @map("create_product_success")
-  createProductError                   Int?     @map("create_product_error")
-  createProductSkippedTotal            Int?     @map("create_product_skipped_total")
-  createProductSkippedAlreadySynced    Int?     @map("create_product_skipped_already_synced")
-  createProductSkippedFailed           Int?     @map("create_product_skipped_failed")
-  isErrorLogExistsForBatch             Boolean  @default(false) @map("is_error_log_exists_for_batch")
-  traceId                              String   @map("trace_id")
-  createdAt                            DateTime @default(now()) @map("created_at")
+  id                                String   @id @default(uuid())
+  tenantId                          String   @map("tenant_id")
+  process                           String
+  requestStartDate                  String?  @map("request_start_date")
+  requestEndDate                    String?  @map("request_end_date")
+  requestProductNumberList          String[] @map("request_product_number_list")
+  total                             Int?
+  createProductTotal                Int?     @map("create_product_total")
+  createProductSuccess              Int?     @map("create_product_success")
+  createProductError                Int?     @map("create_product_error")
+  createProductSkippedTotal         Int?     @map("create_product_skipped_total")
+  createProductSkippedAlreadySynced Int?     @map("create_product_skipped_already_synced")
+  createProductSkippedFailed        Int?     @map("create_product_skipped_failed")
+  isErrorLogExistsForBatch          Boolean  @default(false) @map("is_error_log_exists_for_batch")
+  traceId                           String   @map("trace_id")
+  createdAt                         DateTime @default(now()) @map("created_at")
 
-  tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  tenant TenantInfo        @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   logs   ProductBatchLog[]
 
-  @@map("synced_batch")
-  @@schema("products")
   @@index([tenantId])
   @@index([traceId])
+  @@map("synced_batch")
+  @@schema("products")
 }
 
 model ProductBatchLog {
   id                   String   @id @default(uuid())
   productSyncedBatchId String   @map("product_synced_batch_id")
-  level                String   // "INFO" | "WARN" | "ERROR"
+  level                String // "INFO" | "WARN" | "ERROR"
   step                 String?
   message              String   @db.Text
   data                 Json?
@@ -399,14 +440,14 @@ model ProductBatchLog {
 
   productSyncedBatch ProductSyncedBatch @relation(fields: [productSyncedBatchId], references: [id], onDelete: Cascade)
 
+  @@index([productSyncedBatchId])
   @@map("batch_log")
   @@schema("products")
-  @@index([productSyncedBatchId])
 }
 
 model SyncedBarcode {
   id        String   @id @default(uuid())
-  tenantId String   @map("tenant_id")
+  tenantId  String   @map("tenant_id")
   barcode   String
   productId String?  @map("product_id")
   variantId String?  @map("variant_id")
@@ -414,17 +455,17 @@ model SyncedBarcode {
 
   tenant TenantInfo @relation(fields: [tenantId], references: [id], onDelete: Cascade)
 
-  @@map("synced_barcode")
-  @@schema("products")
+  @@unique([barcode, tenantId])
   @@index([tenantId])
   @@index([barcode])
-  @@unique([barcode, tenantId])
+  @@map("synced_barcode")
+  @@schema("products")
 }
 
 model SyncBatchLog {
   id          String   @id @default(uuid())
   syncBatchId String   @map("sync_batch_id")
-  level       String   // "INFO" | "WARN" | "ERROR"
+  level       String // "INFO" | "WARN" | "ERROR"
   step        String?
   message     String   @db.Text
   data        Json?
@@ -432,8 +473,7 @@ model SyncBatchLog {
 
   syncBatch SyncBatch @relation(fields: [syncBatchId], references: [id], onDelete: Cascade)
 
+  @@index([syncBatchId])
   @@map("batch_log")
   @@schema("sync")
-  @@index([syncBatchId])
 }
-

--- a/routes/shopifyNebimCustomer.js
+++ b/routes/shopifyNebimCustomer.js
@@ -1,8 +1,10 @@
 import express from "express";
 import ShopifyNebimCustomerController from "../controllers/ShopifyNebimCustomerController.js";
+import ValidatorMiddleware from "../middlewares/ValidatorMiddleware.js";
 
 const router = express.Router();
 
 router.post("/consent/:communitaionType", ShopifyNebimCustomerController.updateConsent);
+router.post("/sync_consents", ValidatorMiddleware.validateDatesFromQuery, ShopifyNebimCustomerController.syncConsents);
 
 export default router;

--- a/tests/business/ConsentAuditBusiness.test.js
+++ b/tests/business/ConsentAuditBusiness.test.js
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockLog = {
+  createPending: jest.fn(),
+  complete: jest.fn(),
+};
+
+await jest.unstable_mockModule('../../models/db/postgres/CustomerConsentTransferLog.js', () => ({
+  default: mockLog,
+}));
+await jest.unstable_mockModule('../../helpers/CLSHelper.js', () => ({
+  default: { get: jest.fn(() => 'trace-1') },
+}));
+await jest.unstable_mockModule('../../helpers/StringHelper.js', () => ({
+  default: { generateUUID: jest.fn(() => '00000000-0000-4000-8000-000000000001') },
+}));
+await jest.unstable_mockModule('../../core/CoreClass.js', () => ({
+  default: jest.fn().mockImplementation((tenant) => ({ tenant })),
+}));
+
+const { default: ConsentAuditBusiness } = await import('../../business/ConsentAuditBusiness.js');
+
+describe('ConsentAuditBusiness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLog.createPending.mockResolvedValue({ id: 'log-1' });
+    mockLog.complete.mockResolvedValue({ id: 'log-1' });
+  });
+
+  it('writes pending before the target call and stores the raw target response', async () => {
+    const audit = new ConsentAuditBusiness({
+      id: 'tenant-1',
+      name: 'shop',
+      shopify: { domain: 'shop.myshopify.com' },
+    }, {
+      sourceSystem: 'NEBIM',
+      targetSystem: 'SHOPIFY',
+      triggerType: 'CRON',
+    });
+
+    const result = await audit.execute(
+      { operation: 'UPDATE_EMAIL_CONSENT', channel: 'EMAIL' },
+      { customerId: 'customer-1' },
+      async () => ({ data: { updated: true } }),
+    );
+
+    expect(result).toEqual({ data: { updated: true } });
+    expect(mockLog.createPending.mock.invocationCallOrder[0])
+      .toBeLessThan(mockLog.complete.mock.invocationCallOrder[0]);
+    expect(mockLog.complete).toHaveBeenCalledWith('log-1', expect.objectContaining({
+      status: 'SUCCESS',
+      targetResponseRaw: '{"data":{"updated":true}}',
+    }));
+  });
+
+  it('stores raw target errors and rethrows', async () => {
+    const audit = new ConsentAuditBusiness({ id: 'tenant-1' }, {
+      sourceSystem: 'SHOPIFY',
+      targetSystem: 'NEBIM',
+      triggerType: 'WEBHOOK',
+    });
+    const error = Object.assign(new Error('Nebim failed'), {
+      response: { status: 500, data: { Exception: 'failure' } },
+    });
+
+    await expect(audit.execute(
+      { operation: 'UPDATE_SMS_CONSENT' },
+      { CurrAccCode: 'C001' },
+      async () => { throw error; },
+    )).rejects.toThrow('Nebim failed');
+
+    expect(mockLog.complete).toHaveBeenCalledWith('log-1', expect.objectContaining({
+      status: 'FAILED',
+      targetHttpStatus: 500,
+      targetResponseRaw: '{"Exception":"failure"}',
+    }));
+  });
+});

--- a/tests/business/CustomerConsentSyncBusiness.test.js
+++ b/tests/business/CustomerConsentSyncBusiness.test.js
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockNebim = { runProc: jest.fn() };
+const mockShopify = { query: jest.fn() };
+const auditCalls = [];
+const mockAudit = {
+  execute: jest.fn(async (metadata, request, executor) => {
+    auditCalls.push({ metadata, request });
+    return executor();
+  }),
+};
+
+await jest.unstable_mockModule('../../apis/NebimV3IntegratorAPI.js', () => ({
+  default: jest.fn().mockImplementation(() => mockNebim),
+}));
+await jest.unstable_mockModule('../../apis/ShopifyGqlAPI.js', () => ({
+  default: jest.fn().mockImplementation(() => mockShopify),
+}));
+await jest.unstable_mockModule('../../business/ConsentAuditBusiness.js', () => ({
+  default: jest.fn().mockImplementation(() => mockAudit),
+}));
+await jest.unstable_mockModule('../../core/CoreClass.js', () => ({
+  default: jest.fn().mockImplementation((tenant) => ({
+    tenant,
+    logger: { error: jest.fn() },
+    throws(message) { throw new Error(message); },
+  })),
+}));
+
+const { default: CustomerConsentSyncBusiness } = await import('../../business/CustomerConsentSyncBusiness.js');
+
+describe('CustomerConsentSyncBusiness', () => {
+  let tenant;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    auditCalls.length = 0;
+    tenant = {
+      id: 'tenant-1',
+      name: 'test-shop',
+      nebim: {
+        host: 'https://nebim.test',
+        user: 'user',
+        userGroup: 'group',
+        customer: { phoneType: '7' },
+        procNames: { customer: { concents: 'sp_GO_GetCustomerConcents' } },
+      },
+      shopify: { decyrptedApiKey: 'token' },
+    };
+  });
+
+  it('updates an existing Shopify email consent directly from RunProc rows', async () => {
+    mockNebim.runProc.mockResolvedValue([{
+      CanSendAdvert: true,
+      SMS: false,
+      Email: true,
+      CurrAccCode: 'C001',
+      CommunicationTypeCode: '3',
+      CommAddress: 'customer@example.com',
+      LastUpdatedDate: '2026-08-18T10:30:00Z',
+    }]);
+    mockShopify.query
+      .mockResolvedValueOnce({
+        data: { customers: { nodes: [{ id: 'gid://shopify/Customer/1', email: 'customer@example.com', phone: null }] } },
+      })
+      .mockResolvedValueOnce({
+        data: { customerEmailMarketingConsentUpdate: { customer: { id: 'gid://shopify/Customer/1' }, userErrors: [] } },
+      });
+
+    const business = new CustomerConsentSyncBusiness(tenant);
+    const result = await business.sync('2026-08-17T00:00:00Z');
+
+    expect(mockNebim.runProc).toHaveBeenCalledWith('sp_GO_GetCustomerConcents', {
+      Date: '2026-08-17T00:00:00Z',
+    });
+    expect(result).toEqual({ received: 1, updated: 1, notFound: 0, ambiguous: 0, skipped: 0, failed: 0 });
+    expect(auditCalls.map((call) => call.metadata.operation)).toEqual(['FIND_CUSTOMER', 'UPDATE_EMAIL_CONSENT']);
+  });
+
+  it('does not create a customer when the Nebim customer is absent from Shopify', async () => {
+    mockNebim.runProc.mockResolvedValue([{
+      CanSendAdvert: false,
+      SMS: true,
+      Email: false,
+      CurrAccCode: 'STORE-CUSTOMER',
+      CommunicationTypeCode: '7',
+      CommAddress: '05551234567',
+      LastUpdatedDate: '2026-08-18T10:30:00Z',
+    }]);
+    mockShopify.query.mockResolvedValue({ data: { customers: { nodes: [] } } });
+
+    const business = new CustomerConsentSyncBusiness(tenant);
+    const result = await business.sync('2026-08-17T00:00:00Z');
+
+    expect(result.notFound).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(mockShopify.query).toHaveBeenCalledTimes(1);
+    expect(auditCalls.map((call) => call.metadata.operation)).toEqual(['FIND_CUSTOMER']);
+  });
+
+  it('uses the tenant phone type and updates an existing Shopify SMS consent', async () => {
+    mockNebim.runProc.mockResolvedValue([{
+      CanSendAdvert: false,
+      SMS: true,
+      Email: false,
+      CurrAccCode: 'C002',
+      CommunicationTypeCode: '7',
+      CommAddress: '05551234567',
+      LastUpdatedDate: '2026-08-18T11:00:00Z',
+    }]);
+    mockShopify.query
+      .mockResolvedValueOnce({
+        data: { customers: { nodes: [{ id: 'gid://shopify/Customer/2', email: null, phone: '+905551234567' }] } },
+      })
+      .mockResolvedValueOnce({
+        data: { customerSmsMarketingConsentUpdate: { customer: { id: 'gid://shopify/Customer/2' }, userErrors: [] } },
+      });
+
+    const business = new CustomerConsentSyncBusiness(tenant);
+    const result = await business.sync('2026-08-17T00:00:00Z');
+
+    expect(result.updated).toBe(1);
+    expect(mockShopify.query.mock.calls[0][1]).toEqual({ query: 'phone:+905551234567' });
+    expect(mockShopify.query.mock.calls[1][1]).toEqual({
+      input: {
+        customerId: 'gid://shopify/Customer/2',
+        smsMarketingConsent: {
+          marketingState: 'UNSUBSCRIBED',
+          marketingOptInLevel: 'SINGLE_OPT_IN',
+          consentUpdatedAt: '2026-08-18T11:00:00.000Z',
+        },
+      },
+    });
+    expect(auditCalls.map((call) => call.metadata.operation)).toEqual(['FIND_CUSTOMER', 'UPDATE_SMS_CONSENT']);
+  });
+});

--- a/tests/controllers/ShopifyNebimCustomerController.test.js
+++ b/tests/controllers/ShopifyNebimCustomerController.test.js
@@ -6,6 +6,9 @@ const mockCustomerBusiness = {
 };
 
 const mockCustomerBusinessClass = jest.fn().mockImplementation(() => mockCustomerBusiness);
+const mockConsentSyncBusiness = {
+  sync: jest.fn(),
+};
 
 const mockCoreController = {
   response: jest.fn(),
@@ -13,6 +16,10 @@ const mockCoreController = {
 
 await jest.unstable_mockModule('../../business/nebim/CustomerBusiness.js', () => ({
   default: mockCustomerBusinessClass,
+}));
+
+await jest.unstable_mockModule('../../business/CustomerConsentSyncBusiness.js', () => ({
+  default: jest.fn().mockImplementation(() => mockConsentSyncBusiness),
 }));
 
 await jest.unstable_mockModule('../../core/CoreControler.js', () => ({
@@ -68,7 +75,10 @@ describe('ShopifyNebimCustomerController', () => {
       await ShopifyNebimCustomerController.updateConsent(mockReq, mockRes);
 
       expect(mockCustomerBusinessClass).toHaveBeenCalledWith(mockTenant);
-      expect(mockCustomerBusiness.updateConsent).toHaveBeenCalledWith(mockReq.body, 'email');
+      expect(mockCustomerBusiness.updateConsent).toHaveBeenCalledWith(mockReq.body, 'email', {
+        sourceEventId: null,
+        sourcePayloadRaw: mockReq.body,
+      });
       expect(mockCoreController.response).toHaveBeenCalledWith(mockRes, {
         status: HttpStatusCodes.SUCCESS,
         content: { CustomerCode: 'CUST001' },


### PR DESCRIPTION
## Summary

- fetch consent deltas directly through Nebim Integrator `RunProc`; no `GetModel` call is used in the Nebim → Shopify flow
- interpret communication type `3` as email and the tenant-configured phone type as SMS
- find exact Shopify customers and update marketing consent only when exactly one customer exists; never create customers for store-only Nebim records
- audit Shopify → Nebim webhooks and Nebim → Shopify cron calls with source/target direction, request data, raw target responses, status, trace, and consent metadata
- preserve target HTTP/error payloads for failed audit records

## Dependencies / rollout

- Database/schema PR must deploy first: https://github.com/Gonextso/config-api/pull/5
- Procedure/settings PR: https://github.com/Gonextso/nebim-integration-app/pull/13
- Cron scheduling PR: https://github.com/Gonextso/cron-builder/pull/2
- Housekeeping retention regression PR: https://github.com/Gonextso/housekeeping-service/pull/1

## Validation

- `npx prisma validate`
- `npm test -- --runInBand tests/business/ConsentAuditBusiness.test.js tests/business/CustomerConsentSyncBusiness.test.js tests/controllers/ShopifyNebimCustomerController.test.js`

## Safety behavior

- a missing Shopify customer is counted as `notFound` and skipped
- an ambiguous exact match is skipped
- the sync checkpoint is advanced by cron-builder only when the complete batch succeeds
- The full Actions test matrix is already failing on `dev` (latest baseline: https://github.com/Gonextso/integration-api/actions/runs/31844310141) because of existing Prisma ESM and stale shared test expectations. Code quality and all scoped consent tests pass in this PR.
