### PR TITLE
fix: normalize null run proc parameters

### DIFF
--- a/apis/NebimV3IntegratorAPI.js
+++ b/apis/NebimV3IntegratorAPI.js
@@ -7,6 +7,10 @@ import {
     friendlyNebimError,
 } from "../helpers/NebimErrorHelper.js";
 
+const normalizeRunProcParameters = parameters => Object.fromEntries(
+    Object.entries(parameters ?? {}).map(([key, value]) => [key, value === null ? "" : value])
+);
+
 export default class NebimV3IntegratorAPI extends CoreAPI {
     constructor(tenant) {
         super(tenant);
@@ -126,7 +130,7 @@ export default class NebimV3IntegratorAPI extends CoreAPI {
     runProc = async (procName, parameters) => await this.connectionProvider(async headers => {
         const response = await this.httpRequest.post(`${this.tenant.nebim.host}/IntegratorService/RunProc`, {
             "ProcName": procName,
-            ...parameters
+            ...normalizeRunProcParameters(parameters)
         }, {
             headers: headers
         });
@@ -138,7 +142,7 @@ export default class NebimV3IntegratorAPI extends CoreAPI {
     runProcReturnSingle = async (procName, parameters) => await this.connectionProvider(async headers => {
         const response = await this.httpRequest.post(`${this.tenant.nebim.host}/IntegratorService/RunProcReturnSingle`, {
             "ProcName": procName,
-            ...parameters
+            ...normalizeRunProcParameters(parameters)
         }, {
             headers: headers
         });

--- a/tests/apis/NebimV3IntegratorAPI.test.js
+++ b/tests/apis/NebimV3IntegratorAPI.test.js
@@ -370,6 +370,38 @@ describe('NebimV3IntegratorAPI', () => {
       );
       expect(result).toEqual({ result: 'success' });
     });
+
+    it('should convert null parameters to empty strings', async () => {
+      const mockToken = 'token';
+      mockCache.get.mockResolvedValue({
+        token: mockToken,
+        expiryDate: new Date(Date.now() + 10000),
+      });
+      mockHttpRequest.post.mockResolvedValue({
+        data: { result: 'success' },
+      });
+
+      await api.runProc('sp_GO_GetProductInventory', {
+        Date: '2026-08-19T13:55:00.000Z',
+        BarcodeTypeCode: '1',
+        OrderStoreCode: null,
+        ResponsibiltyAreaCode: 'WEB',
+        IncludeBlocked: false,
+      });
+
+      expect(mockHttpRequest.post).toHaveBeenCalledWith(
+        'https://test.nebim.com/IntegratorService/RunProc',
+        {
+          ProcName: 'sp_GO_GetProductInventory',
+          Date: '2026-08-19T13:55:00.000Z',
+          BarcodeTypeCode: '1',
+          OrderStoreCode: '',
+          ResponsibiltyAreaCode: 'WEB',
+          IncludeBlocked: false,
+        },
+        expect.any(Object)
+      );
+    });
   });
 
   describe('runProcReturnSingle', () => {
@@ -402,6 +434,32 @@ describe('NebimV3IntegratorAPI', () => {
         }
       );
       expect(result).toEqual({ result: 'single' });
+    });
+
+    it('should convert null parameters to empty strings', async () => {
+      const mockToken = 'token';
+      mockCache.get.mockResolvedValue({
+        token: mockToken,
+        expiryDate: new Date(Date.now() + 10000),
+      });
+      mockHttpRequest.post.mockResolvedValue({
+        data: { result: 'single' },
+      });
+
+      await api.runProcReturnSingle('TestProc', {
+        OptionalCode: null,
+        Count: 0,
+      });
+
+      expect(mockHttpRequest.post).toHaveBeenCalledWith(
+        'https://test.nebim.com/IntegratorService/RunProcReturnSingle',
+        {
+          ProcName: 'TestProc',
+          OptionalCode: '',
+          Count: 0,
+        },
+        expect.any(Object)
+      );
     });
 
     it('should return empty object when data is null', async () => {
@@ -587,4 +645,3 @@ describe('NebimV3IntegratorAPI', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

- normalize top-level `null` stored-procedure parameters to empty strings before sending JSON
- apply the behavior consistently to both `RunProc` and `RunProcReturnSingle`
- preserve non-null values such as `false`, `0`, dates, and strings

## Root cause

Nebim Integrator rejects some stored-procedure requests when optional parameters are serialized as JSON `null`. These procedure parameters expect an empty string when no value is supplied.

## Impact

Requests such as `sp_GO_GetProductInventory` now send `OrderStoreCode: ""` instead of `OrderStoreCode: null`. The same normalization applies to every stored-procedure call through these two shared methods.

## Validation

- `npm test -- --runInBand tests/apis/NebimV3IntegratorAPI.test.js -t "convert null parameters"` — 2 tests passed
- `git diff --check` — passed

The complete API test file currently has 8 unrelated pre-existing failures in stale `checkConnection` expectations; the new scoped regression tests pass.
